### PR TITLE
Update module declaration to match new org name

### DIFF
--- a/examples/minimal/main.go
+++ b/examples/minimal/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/voi-go/svc"
+	"github.com/voi-oss/svc"
 	"go.uber.org/zap"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/voi-go/svc
+module github.com/voi-oss/svc
 
 require (
 	github.com/blendle/zapdriver v1.3.1


### PR DESCRIPTION
Since the repository's path changed, we should update its module declaration to avoid import errors such as:

```
github.com/voi-oss/svc: github.com/voi-oss/svc@v0.5.2: parsing go.mod:
module declares its path as: github.com/voi-go/svc
        but was required as: github.com/voi-oss/svc
```