### PR TITLE
Remove references to voi-go repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ This can be done easily using the [`-s`](https://github.com/git/git/blob/b2c150d
 
 The official support channels, for both users and contributors, are:
 
-- GitHub [issues](https://github.com/voi-go/svc/issues)*
+- GitHub [issues](https://github.com/voi-oss/svc/issues)*
 
 
 ## How to Contribute
@@ -90,5 +90,5 @@ We're much more likely to approve your changes if you:
 * Maintain backward compatibility.
 
 [fork]: https://github.com/uber-go/zap/fork
-[open-issue]: https://github.com/voi-go/svc/issues/new
+[open-issue]: https://github.com/voi-oss/svc/issues/new
 [commit-message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 # SVC - Worker life-cycle manager
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/voi-go/svc?style=flat-square)](https://goreportcard.com/report/github.com/voi-go/svc)
-[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/voi-go/svc)
+[![Go Report Card](https://goreportcard.com/badge/github.com/voi-oss/svc?style=flat-square)](https://goreportcard.com/report/github.com/voi-oss/svc)
+[![Go Doc](https://img.shields.io/badge/godoc-reference-blue.svg?style=flat-square)](http://godoc.org/github.com/voi-oss/svc)
 [![codecov](https://codecov.io/gh/voi-oss/svc/branch/master/graph/badge.svg)](https://codecov.io/gh/voi-oss/svc)
 
 SVC is a framework that creates a long-running service process, managing the
@@ -125,7 +125,7 @@ See [net/http/pprof](https://godoc.org/net/http/pprof).
 package main
 
 import (
-	"github.com/voi-go/svc"
+	"github.com/voi-oss/svc"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Sample code on README.md is broken due this incorrect target. 

Report card and links to issues are also incorrect