### PR TITLE
Improve documentation for WithLogLevelHandlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ See [Prometheus' http handler](https://godoc.org/github.com/prometheus/client_go
 `PUT /loglevel` sets a new log level. This can be useful to temporarily change
 the service's log level to `debug` to allow for better troubleshooting.
 
+This option must be passed after other options that manipulate the logger to have any effect on that logger option.
+
 See [Zap's http_handler.go](https://github.com/uber-go/zap/blob/master/http_handler.go).
 
 

--- a/options.go
+++ b/options.go
@@ -43,7 +43,8 @@ func WithRouter(router *http.ServeMux) Option {
 }
 
 // WithLogLevelHandlers is an option that sets up HTTP routes to read write the
-// log level.
+// log level. This option must be passed after other options that manipulate the
+// logger to have any effect on that logger option.
 func WithLogLevelHandlers() Option {
 	return func(s *SVC) error {
 		s.Router.Handle("/loglevel", s.atom)


### PR DESCRIPTION
The order of the options matters when it comes to logging as a router handler is set up against the log level. If the logger is switched out after this route is setup the WithLogLevelHandlers() option has no effect on the new logger. The solution is to set the WithLogLevelHandlers() last.